### PR TITLE
remove \r if found

### DIFF
--- a/lib/dot-env.js
+++ b/lib/dot-env.js
@@ -9,6 +9,7 @@ try {
         if (!line) {
             return;
         }
+        line = line.replace('\r', '');
         line = line.split('=');
         env[line[0]] = line[1];
     });


### PR DESCRIPTION
if `.env` file is saved on windows it will add `\r\n` so to fix that I am stripping `\r` before running split with `\n`