### PR TITLE
Add support for command string

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Better NPM scripts runner
 # Usage in package.json
 
 From this:
-```
+```JSON
 {
   "scripts": {
     "build:dist": "NODE_ENV=development webpack --config $npm_package_webpack --progress --colors",
@@ -37,22 +37,18 @@ From this:
 ```
 
 To this:
-```
+```JSON
 {
   "devDependencies": {
     "better-npm-run": "~0.0.1"
   },
   "scripts": {
     "build:dist": "better-npm-run build:dist",
+    "build:prod": "better-npm-run build:prod",
     "test": "better-npm-run test"
   },
   "betterScripts": {
-    "build:dist": {
-      "command": "webpack --config $npm_package_webpack --progress --colors",
-      "env": {
-        "NODE_ENV": "development"
-      }
-    },
+    "build:dist": "webpack --config $npm_package_webpack --progress --colors",
     "build:prod": {
       "command": "webpack --config $npm_package_webpack --progress --colors",
       "env": {
@@ -69,12 +65,15 @@ To this:
 }
 ```
 
+_The `betterScripts` script definition can either be a string or sub-object with `command` and `env` attributes._
+
 # .env File
 
 If you have an `.env` file in your project root it will be loaded on every command
 
 ```
 NODE_PATH=./:./lib
+NODE_ENV=development
 PORT=5000
 ```
 
@@ -121,5 +120,3 @@ using the shorter alias
   "dev": "shell-exec 'bnr install-hooks' 'bnr watch-client' 'bnr start-dev' 'bnr start-dev-api' 'bnr start-dev-worker' 'bnr start-dev-socket'",
 }
 ```
-
-

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -6,7 +6,7 @@ var objectAssign = require('object-assign');
 module.exports = function exec(script) {
 
 	var argv = process.argv.splice(3);
-	var command = script.command + ' ' + argv.join(' ');
+	var command = (typeof script === 'string' ? script : script.command) + ' ' + argv.join(' ');
 
 	script.env = script.env || {};
 

--- a/package.json
+++ b/package.json
@@ -18,15 +18,26 @@
     "better-npm-run": "index.js"
   },
   "scripts": {
-    "test": "node index.js test --test"
+    "test:env": "node index.js test:env",
+    "test:params": "node index.js test:params --test",
+    "test:command:object": "node index.js test:command:object",
+    "test:command:string": "node index.js test:command:string",
+    "test": "npm run test:env && npm run test:params && npm run test:command:object && npm run test:command:string"
   },
   "dependencies": {
     "dotenv": "^2.0.0",
     "object-assign": "^4.0.1"
   },
   "betterScripts": {
-    "test": {
-      "command": "node test.js",
+    "test:command:string": "node ./test/command.js",
+    "test:command:object": {
+      "command": "node ./test/command.js"
+    },
+    "test:params": {
+      "command": "node ./test/params.js"
+    },
+    "test:env": {
+      "command": "node ./test/env.js",
       "env": {
         "FOO": "bar"
       }

--- a/test/command.js
+++ b/test/command.js
@@ -1,0 +1,2 @@
+console.log('Command executed!');
+process.exit(0);

--- a/test/env.js
+++ b/test/env.js
@@ -1,13 +1,8 @@
 
-
 if (process.env.TEST_ENV !== "TEST_VALUE") {
     throw new Error(".env file is not loaded");
 }
 
 if (process.env.FOO !== "bar") {
     throw new Error("env params are missing")
-}
-
-if (process.argv[2] !== "--test") {
-    throw new Error('it should accept params');
 }

--- a/test/params.js
+++ b/test/params.js
@@ -1,0 +1,4 @@
+
+if (process.argv[2] !== "--test") {
+    throw new Error('it should accept params');
+}


### PR DESCRIPTION
This Pull Request adds support for accepting a string in the `betterScripts` script definition as well as updates the README with a usage example.

_Note: I also broke out the tests into separate commands/scripts so that each feature could be tested. Let me know if you want me to pull this out and revert the tests._

fixes #47 