### PR TITLE
feature: substitute environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,25 @@ NODE_PATH=./:./lib
 PORT=5000
 ```
 
+# Environment variable substitution
+
+```json
+"betterScripts": {
+  "start": {
+    "command": "node start.js ${COPY_OF_NODE_ENV}",
+    "env": {
+      "FOO": "bar",
+      "COPY_OF_NODE_ENV": "${NODE_ENV}"
+    }
+  }
+}
+```
+
+Environment variables will be substituted into:
+
+- the `command` by means of automatic substitution in `child_process.spawn()`.
+- each of the `env` values using string interpolation.
+
 # Shell scripts
 
 Currently, using [bash variables](http://tldp.org/LDP/abs/html/internalvariables.html) (PWD, USER, etc.) is not possible:
@@ -121,5 +140,3 @@ using the shorter alias
   "dev": "shell-exec 'bnr install-hooks' 'bnr watch-client' 'bnr start-dev' 'bnr start-dev-api' 'bnr start-dev-worker' 'bnr start-dev-socket'",
 }
 ```
-
-

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -11,6 +11,14 @@ module.exports = function exec(script) {
 	script.env = script.env || {};
 
 	var env = objectAssign(process.env, script.env);
+	for (key in env) {
+		if (env.hasOwnProperty(key)) {
+			env[key] = env[key]
+				.replace(/\$\{([^\}]+)\}/g, function (match, p1) {
+					return process.env[p1];
+				});
+		}
+	}
 
 	var sh = 'sh', shFlag = '-c';
 	if (process.platform === 'win32') {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "test": {
       "command": "node test.js",
       "env": {
-        "FOO": "bar"
+        "FOO": "bar",
+        "TEST_ENV_SUBSTITUTION": "${TEST_ENV}"
       }
     }
   }

--- a/test.js
+++ b/test.js
@@ -11,3 +11,7 @@ if (process.env.FOO !== "bar") {
 if (process.argv[2] !== "--test") {
     throw new Error('it should accept params');
 }
+
+if (process.env.TEST_ENV_SUBSTITUTION !== "TEST_VALUE") {
+    throw new Error('it should substitute in env');
+}


### PR DESCRIPTION
- Environment variables will be substituted into:
  - the `command` by means of automatic substitution in
    `child_process.spawn()`.
  - each of the `env` values using string interpolation.
- Tested by adding `"TEST_ENV_SUBSTITUTION": "${TEST_ENV}"`
  to the existing tests

fixes #49