### PR TITLE
Specify configuration sources order

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,2 @@
 TEST_ENV=TEST_VALUE
+TEST_ENV2=overridden

--- a/README.md
+++ b/README.md
@@ -77,6 +77,13 @@ NODE_ENV=development
 PORT=5000
 ```
 
+Environment variables will be merged in the following order:
+* `package.json` options
+* `.env` file content
+* parent `process.env` values
+
+Whoever comes last, will set the actual value.
+
 # Shell scripts
 
 Currently, using [bash variables](http://tldp.org/LDP/abs/html/internalvariables.html) (PWD, USER, etc.) is not possible:

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -10,7 +10,7 @@ module.exports = function exec(script) {
 
 	script.env = script.env || {};
 
-	var env = objectAssign(process.env, script.env);
+	var env = objectAssign({}, script.env, process.env);
 
 	var sh = 'sh', shFlag = '-c';
 	if (process.platform === 'win32') {

--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
   },
   "scripts": {
     "test:env": "node index.js test:env",
+    "test:env-extend": "TEST_ENV2=envvar node index.js test:env-extend",
     "test:params": "node index.js test:params --test",
     "test:command:object": "node index.js test:command:object",
     "test:command:string": "node index.js test:command:string",
-    "test": "npm run test:env && npm run test:params && npm run test:command:object && npm run test:command:string"
+    "test": "npm run test:env && npm run test:env-extend && npm run test:params && npm run test:command:object && npm run test:command:string"
   },
   "dependencies": {
     "dotenv": "^2.0.0",
@@ -39,6 +40,13 @@
     "test:env": {
       "command": "node ./test/env.js",
       "env": {
+        "FOO": "bar"
+      }
+    },
+    "test:env-extend": {
+      "command": "node ./test/env-extend.js",
+      "env": {
+        "TEST_ENV": "overridden",
         "FOO": "bar"
       }
     }

--- a/test/env-extend.js
+++ b/test/env-extend.js
@@ -1,0 +1,11 @@
+if (process.env.FOO !== 'bar') {
+    throw new Error("env variable is not provided");
+}
+
+if (process.env.TEST_ENV !== "TEST_VALUE") {
+    throw new Error(".env file variable is overridden");
+}
+
+if(process.env.TEST_ENV2 !== "envvar") {
+    throw new Error("environment variable is overridden");
+}


### PR DESCRIPTION
Fixes #54.

As you can see, no one existing test was affected, so I think it would be safe to specify behavior that previously was undefined.

Also this behavior conforms with `dotenv` logic, which is also doesn't override `process.env` keys, that were already defined.