### PR TITLE
Revert environment variable precedence to original behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ To this:
 }
 ```
 
-_The `betterScripts` script definition can either be a string or sub-object with `command` and `env` attributes._
+_The `betterScripts` script definition can either be a string or sub-object with `command` and `env` attributes. Values defined in the `env` block will override previously set environment variables._
 
 # .env File
 
-If you have an `.env` file in your project root it will be loaded on every command
+If you have an `.env` file in your project root it will be loaded on every command.
 
 ```
 NODE_PATH=./:./lib
@@ -77,12 +77,7 @@ NODE_ENV=development
 PORT=5000
 ```
 
-Environment variables will be merged in the following order:
-* `package.json` options
-* `.env` file content
-* parent `process.env` values
-
-Whoever comes last, will set the actual value.
+_Environment variables defined in the `betterScripts` script definition will take precedence over `.env` values._
 
 # Shell scripts
 

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -10,7 +10,7 @@ module.exports = function exec(script) {
 
   script.env = script.env || {};
 
-  var env = objectAssign({}, script.env, process.env);
+  var env = objectAssign({}, process.env, script.env);
 
   var sh = 'sh', shFlag = '-c';
   if (process.platform === 'win32') {

--- a/test/env-extend.js
+++ b/test/env-extend.js
@@ -2,10 +2,6 @@ if (process.env.FOO !== 'bar') {
   throw new Error("env variable is not provided");
 }
 
-if (process.env.TEST_ENV !== "TEST_VALUE") {
-  throw new Error(".env file variable is overridden");
-}
-
-if(process.env.TEST_ENV2 !== "envvar") {
+if (process.env.TEST_ENV !== "overridden" || process.env.TEST_ENV2 !== "envvar") {
   throw new Error("environment variable is overridden");
 }


### PR DESCRIPTION
Package behavior was mistakenly changed in `v0.0.12` (#55) so that _the .env file overrides the `betterScripts` definition_.

**This Pull Request reverts the breaking change and adds better documentation of package behavior and environment variable precedence.**

resolves #56, references #55 #54 #41

---

[Intended behavior](https://github.com/benoror/better-npm-run/issues/56#issuecomment-256709687) of this package is to…
1. load environment variables from `.env` file into the runtime for NPM script execution
2. allow environment variables to be overwritten in `package.json` via `betterScripts` block (see example below)