### PR TITLE
Silent mode feature added. Closing #60 

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,9 @@ using the shorter alias
   "dev": "shell-exec 'bnr install-hooks' 'bnr watch-client' 'bnr start-dev' 'bnr start-dev-api' 'bnr start-dev-worker' 'bnr start-dev-socket'",
 }
 ```
+
+Also for silence output, you can use `-s` or verbose `--silence` flags
+
+```
+bnr watch-client -s
+```

--- a/index.js
+++ b/index.js
@@ -39,7 +39,3 @@ exec(pkg.betterScripts[scriptName], isSilent, function (error, stdout, stderr) {
   }
 });
 
-//
-// Silent mode feature added. Closing #60
-//
-// Running with -s or --silent flag will silence not only npm noise but also info messages of better-npm-run itself.

--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 
-console.log('running better-npm-run in', process.cwd());
+var scriptName = process.argv[2];
+
+var isSilent = process.argv.indexOf('-s') > -1 || process.argv.indexOf('--silent') > -1;
+
+isSilent || console.log('running better-npm-run in', process.cwd());
 var join = require('path').join;
 var fullPackagePath = join(process.cwd(), 'package.json');
 var pkg = require(fullPackagePath);
@@ -14,21 +18,28 @@ if (!pkg.betterScripts) {
   process.stderr.write('ERROR: No betterScripts found!');
   process.exit(1);
 }
-if (!process.argv[2]) {
+if (!scriptName) {
   process.stderr.write('ERROR: No script name provided!');
   process.exit(1);
 }
-if (!pkg.betterScripts[process.argv[2]]) {
-  process.stderr.write('ERROR: No betterScript with name "'+process.argv[2]+'" was found!');
+if (!pkg.betterScripts[scriptName]) {
+  process.stderr.write('ERROR: No betterScript with name "'+scriptName+'" was found!');
   process.exit(1);
 }
 
-console.log('Executing script: ' + process.argv[2] + '\n');
 
-exec(pkg.betterScripts[process.argv[2]], function (error, stdout, stderr) {
+isSilent || console.log('Executing script: ' + scriptName + '\n');
+
+
+exec(pkg.betterScripts[scriptName], isSilent, function (error, stdout, stderr) {
   process.stderr.write(stderr);
   process.stdout.write(stdout);
   if(error !== null) {
     console.log('exec error: '+error);
   }
 });
+
+//
+// Silent mode feature added. Closing #60
+//
+// Running with -s or --silent flag will silence not only npm noise but also info messages of better-npm-run itself.

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -3,7 +3,7 @@ require('dotenv').config({silent: true});
 var spawn = require('child_process').spawn;
 var objectAssign = require('object-assign');
 
-module.exports = function exec(script) {
+module.exports = function exec(script, isSilent) {
 
   var argv = process.argv.splice(3);
   var command = (typeof script === 'string' ? script : script.command) + ' ' + argv.join(' ');
@@ -19,7 +19,7 @@ module.exports = function exec(script) {
     command = '"' + command.trim() + '"';
   }
 
-  console.log('to be executed:', command);
+  isSilent || console.log('to be executed:', command);
   spawn(sh, [shFlag, command], {
     env: env,
     windowsVerbatimArguments: process.platform === 'win32',
@@ -28,4 +28,4 @@ module.exports = function exec(script) {
     process.exit(code);
   });
 
-}
+};

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "test:params": "node index.js test:params --test",
     "test:command:object": "node index.js test:command:object",
     "test:command:string": "node index.js test:command:string",
+    "test:silent": "node index.js test:command:object -s && node index.js test:command:object --silent",
     "test": "npm run test:env && npm run test:env-extend && npm run test:params && npm run test:command:object && npm run test:command:string"
   },
   "dependencies": {


### PR DESCRIPTION
Silent mode feature added. Closing #60 

Running with `-s` or `--silent` flag now will silence not only `npm` noise but also info messages of `better-npm-run` itself.