### PR TITLE
feat: Support more dotenv options

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,8 +123,22 @@ using the shorter alias
 }
 ```
 
-Also for silence output, you can use `-s` or verbose `--silence` flags
+And for silence output, you can use `-s` or verbose `--silence` flags
 
 ```
 bnr watch-client -s
 ```
+
+And you can use `-p` or verbose `--path` specify a custom path of dotenv file
+
+```
+bnr start-dev --path=/custom/path/to/your/env/vars
+```
+
+Also use `-e` or verbose `--encoding` specify the encoding of dotenv file
+
+```
+bnr start-dev --encoding=base64
+```
+
+See [envdot docs](https://github.com/motdotla/dotenv) for more infomation

--- a/README.md
+++ b/README.md
@@ -129,13 +129,13 @@ And for silence output, you can use `-s` or verbose `--silence` flags
 bnr watch-client -s
 ```
 
-And you can use `-p` or verbose `--path` specify a custom path of dotenv file
+And you can use `-p` or verbose `--path` to specify a custom path of dotenv file
 
 ```
 bnr start-dev --path=/custom/path/to/your/env/vars
 ```
 
-Also use `-e` or verbose `--encoding` specify the encoding of dotenv file
+Also use `-e` or verbose `--encoding` to specify the encoding of dotenv file
 
 ```
 bnr start-dev --encoding=base64

--- a/index.js
+++ b/index.js
@@ -3,6 +3,8 @@ var program = require('commander'),
     scriptName = process.argv[2];
 
 program
+  .option('-e, --encoding [type]', 'Specify the encoding of dotenv file')
+  .option('-p, --path [type]', 'Specify a custom path of dotenv file')
   .option('-s, --silent', 'silent')
   .parse(process.argv);
 
@@ -42,4 +44,3 @@ exec(pkg.betterScripts[scriptName], program, function (error, stdout, stderr) {
     console.log('exec error: '+error);
   }
 });
-

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -2,11 +2,9 @@ var spawn = require('child_process').spawn,
     objectAssign = require('object-assign');
 
 module.exports = function exec(script, program) {
-  var dotenvConfig = { silent: true };
-  ['encoding', 'path'].forEach(function (key) {
-    if (key in program) {
-      dotenvConfig[key] = program[key];
-    }
+  var dotenvConfig = objectAssign({ silent: true }, {
+    encoding: program.encoding,
+    path: program.path
   });
 
   require('dotenv').config(dotenvConfig);

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -1,9 +1,15 @@
-require('dotenv').config({silent: true});
-
 var spawn = require('child_process').spawn,
     objectAssign = require('object-assign');
 
 module.exports = function exec(script, program) {
+  var dotenvConfig = { silent: true };
+  ['encoding', 'path'].forEach(function (key) {
+    if (key in program) {
+      dotenvConfig[key] = program[key];
+    }
+  });
+
+  require('dotenv').config(dotenvConfig);
 
   var argv = process.argv.splice(3),
       command = (typeof script === 'string' ? script : script.command) + ' ' + argv.join(' ');


### PR DESCRIPTION
Sometimes, I want to control dotenv more precisely, so I added some options to dotenv. Options are as follows:

Options
Path
Default: .env
You can specify a custom path if your file containing environment
variables is named or located differently.
`better-npm-run your-task --path=/custom/path/to/your/env/vars`
or use short name 
`better-npm-run your-task -p /custom/path/to/your/env/vars`

Encoding
Default: utf8
You may specify the encoding of your file containing environment
variables using this option.
`better-npm-run your-task -e base64`
