### PR TITLE
Don't pass bnr flags to specified command

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,19 +126,19 @@ using the shorter alias
 And for silence output, you can use `-s` or verbose `--silence` flags
 
 ```
-bnr watch-client -s
+bnr -s watch-client
 ```
 
 And you can use `-p` or verbose `--path` to specify a custom path of dotenv file
 
 ```
-bnr start-dev --path=/custom/path/to/your/env/vars
+bnr --path=/custom/path/to/your/env/vars start-dev
 ```
 
 Also use `-e` or verbose `--encoding` to specify the encoding of dotenv file
 
 ```
-bnr start-dev --encoding=base64
+bnr --encoding=base64 start-dev
 ```
 
 See [envdot docs](https://github.com/motdotla/dotenv) for more infomation

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
-var program = require('commander'),
-    scriptName = process.argv[2];
+var program = require('commander');
 
 program
   .option('-e, --encoding [type]', 'Specify the encoding of dotenv file')
   .option('-p, --path [type]', 'Specify a custom path of dotenv file')
   .option('-s, --silent', 'silent')
   .parse(process.argv);
+var scriptName = program.args[0];
 
 if (!program.silent) {
   console.log('running better-npm-run in', process.cwd());

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -9,7 +9,12 @@ module.exports = function exec(script, program) {
 
   require('dotenv').config(dotenvConfig);
 
-  var argv = process.argv.splice(3),
+  var argvIndex = -1;
+      firstArg = program.args[0];
+  if (firstArg !== undefined) {
+    argvIndex = process.argv.indexOf(firstArg);
+  }
+  var argv = argvIndex === -1 ? [] : process.argv.splice(argvIndex + 1),
       command = (typeof script === 'string' ? script : script.command) + ' ' + argv.join(' ');
 
   script.env = script.env || {};

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "test:env": "node index.js test:env",
     "test:env-extend": "TEST_ENV2=envvar node index.js test:env-extend",
-    "test:params": "node index.js test:params --test",
+    "test:params": "node index.js --silent test:params --test",
     "test:command:object": "node index.js test:command:object",
     "test:command:string": "node index.js test:command:string",
     "test:silent": "node index.js test:command:object -s && node index.js test:command:object --silent",

--- a/test/params.js
+++ b/test/params.js
@@ -1,3 +1,6 @@
+if (process.argv[2] === "--silent") {
+	throw new Error('it should eat extra arguments');
+}
 if (process.argv[2] !== "--test") {
   throw new Error('it should accept params');
 }


### PR DESCRIPTION
Currently bnr-specific flags are forwarded to the ran command which seems like a pretty bad idea.

Consider `package.json`:
```json
{
  "scripts": {
    "hello": "bnr hello -s"
  },
  "betterScripts": {
    "hello": {
      "command": "node hello.js"
    }
  },
  "dependencies": {
    "better-npm-run": "0.0.15"
  }
}
```

And `hello.js` is just `console.log(process.argv)`.

Running `npm run hello` will output:
`[ 'node', 'hello.js', '-s' ]`

This is undesirable because if the command you are running also has some kind of meaning assigned to these flags then you can't use bnr.

This pull request allows you to put bnr flags before the specified command. Those arguments will be consumed by bnr and then the command only gets arguments which appeared after. This shouldn't break existing applications because the behavior remains the same for the old way. I've updated the README with the preferred way of passing flags.

If you don't mind breaking existing applications (major semvar update), then a more correct fix would be to have bnr ignore the flags after the specified command and just forward them. Perhaps you can do that some time in the future after landing this patch.